### PR TITLE
new parser pattern

### DIFF
--- a/.github/workflows/pytest_on_push_to_any_branch.yaml
+++ b/.github/workflows/pytest_on_push_to_any_branch.yaml
@@ -31,4 +31,4 @@ jobs:
 
     - name: run pytest
       run: |
-          poetry run python -m pytest tests/
+          poetry run python -m pytest tests/*


### PR DESCRIPTION
rather than subclass to extend, instead pass in a callback and a list of
target keys. This lets us have the main parser still contain all the
base parsing code and be the only place where node objects are created,
while still allowing for the actual syntax of the config to be modified
as needed by each different parser