### PR TITLE
Feature - symbolic nsids via secondlifenodes

### DIFF
--- a/tests/test_secondLifeNode.py
+++ b/tests/test_secondLifeNode.py
@@ -1,6 +1,7 @@
 import pytest
 
 from thewired.namespace import SecondLifeNode, Namespace
+from functools import partial
 
 @pytest.fixture
 def mock_attribute_map():
@@ -26,3 +27,39 @@ def test_SecondLife_map1(mock_attribute_map):
     MapNode = SecondLifeNode(nsid=".test.nsid.string", namespace=NS, secondlife=mock_attribute_map)
     assert MapNode.attribute_1 == mock_attribute_map.get('attribute_1')
     assert MapNode.attribute_3 == mock_attribute_map.get('attribute_3').__call__()
+
+def test_lookup_ns():
+    ns = Namespace()
+    lookup_ns = Namespace()
+
+    sl = {
+            "foo" : "nsid://.x.y",
+    }
+
+    slnfactory = partial(SecondLifeNode, secondlife_ns=lookup_ns, secondlife=sl)
+    ns.add('.a.b.c.d.e', slnfactory)
+    lookup_ns.add('.x.y')
+    assert str(ns.root.a.b.c.d.e.foo.nsid) == ".x.y"
+
+def test_lookup_ns_callable():
+
+    class SomeCallableClass:
+        def __call__(self):
+            magic_string = "Tusks' Dissolve is a great album"
+            print(magic_string)
+            return magic_string
+
+    ns = Namespace()
+    lookup_ns = Namespace()
+
+    sl = {
+            "foo" : "nsid://.x.y",
+    }
+
+    slnfactory = partial(SecondLifeNode, secondlife_ns=lookup_ns, secondlife=sl)
+    ns.add('.a.b.c.d.e', slnfactory)
+
+    y_factory = partial(CallableDelegateNode, delegate=SomeCallableClass())
+    lookup_ns.add('.x.y', y_factory)
+    assert str(ns.root.a.b.c.d.e.foo.nsid) == ".x.y"
+    assert ns.root.a.b.c.d.e.foo() == "Tusks' Dissolve is a great album"

--- a/tests/test_secondLifeNode.py
+++ b/tests/test_secondLifeNode.py
@@ -1,6 +1,6 @@
 import pytest
 
-from thewired.namespace import SecondLifeNode, Namespace
+from thewired.namespace import SecondLifeNode, Namespace, CallableDelegateNode
 from functools import partial
 
 @pytest.fixture

--- a/thewired/exceptions.py
+++ b/thewired/exceptions.py
@@ -37,3 +37,9 @@ class NsidSanitizationError(NsidError):
 
 class InvalidNsidError(NsidError):
     pass
+
+class SecondLifeError(Exception):
+    pass
+
+class SecondLifeNsLookupError(SecondLifeError, NamespaceLookupError):
+    pass

--- a/thewired/namespace/namespace.py
+++ b/thewired/namespace/namespace.py
@@ -95,7 +95,7 @@ class Namespace(SimpleNamespace):
         self._validate_namespace_nsid_head(nsid)
         _nsid_ = Nsid(nsid)
         current_node = self.root
-        nsid_segments = list_nsid_segments(nsid)[1:] #- skip initial root segment
+        nsid_segments = list_nsid_segments(nsid)[1:] #- attribute names to get; skip initial empty string ""
 
         n = 0
         while current_node.nsid != _nsid_:
@@ -103,7 +103,7 @@ class Namespace(SimpleNamespace):
             try:
                 nsid_segment = nsid_segments[n]
             except IndexError as err:
-                raise NamespaceInternalError(f"while looking for nsid \"{_nsid_}\", ran out of nsid_segments: {nsid_segments} at index {n}") from err
+                raise NamespaceInternalError(f"while looking for nsid \"{_nsid_}\", ran out of nsid_segments: {nsid_segments} at index {n} ({current_node=}") from err
             try:
                 current_node = getattr(current_node, nsid_segment)
                 if not isinstance(current_node, NamespaceNodeBase):

--- a/thewired/namespace/nsid.py
+++ b/thewired/namespace/nsid.py
@@ -174,7 +174,7 @@ def make_child_nsid(parent_nsid, child, separator='.'):
 def get_parent_nsid(nsid, parent_num=1, separator='.'):
     validate_nsid(nsid)
     retval = separator.join(
-        nsid.split(separator)[0:-parent_num]
+        str(nsid).split(separator)[0:-parent_num]
     )
     if retval == '':
         return '.'
@@ -183,7 +183,7 @@ def get_parent_nsid(nsid, parent_num=1, separator='.'):
 
 
 def get_nsid_parts(nsid, separator='.'):
-    return nsid.split(separator)
+    return str(nsid).split(separator)
 
 def list_nsid_segments(nsid, separator='.', skip_root=False) -> List:
     if nsid == separator:
@@ -230,6 +230,8 @@ def strip_prefix(prefix, nsid, separator='.'):
 
 
 def strip_common_prefix(nsid1, nsid2, separator='.'):
+    nsid1 = str(nsid1)
+    nsid2 = str(nsid2)
     common_prefix = find_common_prefix(nsid1, nsid2, separator=separator)
     common_prefix_len = len(common_prefix.split(separator))
 


### PR DESCRIPTION
attributes can be references to another node in another namespace and we'll look it up dynamically every time the attribute is referenced.