### PR TITLE
NamespaceHandle should return Nodes with NSIDs that make sense for the Handle

### DIFF
--- a/tests/test_delegatenode.py
+++ b/tests/test_delegatenode.py
@@ -17,6 +17,7 @@ def test_delegate_1():
 
     assert(isinstance(node, NamespaceNodeBase))
     assert(isinstance(node, DelegateNode))
+    assert node.a == 15
     assert(node.get_a_x2()[0] == 15)
     assert(node.get_a_x2()[1] == 15)
 

--- a/tests/test_handlenode.py
+++ b/tests/test_handlenode.py
@@ -1,0 +1,10 @@
+from thewired import Namespace, HandleNode, DelegateNode, NamespaceNodeBase
+
+
+def test_get():
+    ns = Namespace()
+    ns.add('.a.b.c.d.e.f.g')
+    handle = ns.get_handle('.a.b.c')
+    node = handle.get('.d.e.f')
+    assert isinstance(node, HandleNode)
+    assert str(node.nsid) == '.d.e.f'

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -5,7 +5,7 @@ import thewired.namespace
 from thewired.namespace.nsid import make_child_nsid
 from thewired.exceptions import InvalidNsidError, NamespaceLookupError
 from thewired.exceptions import NamespaceCollisionError
-from thewired.namespace import Namespace, NamespaceNodeBase
+from thewired.namespace import Namespace, NamespaceNodeBase, HandleNode
 
 class TestNamespace(unittest.TestCase):
     def test_default_instantiation(self):
@@ -181,7 +181,7 @@ class TestNamespace(unittest.TestCase):
     def test_get_nonexisting_handle(self):
         ns = Namespace()
         handle = ns.get_handle(".something.totally.new", create_nodes=True)
-        assert handle.get('.').nsid.nsid == ".something.totally.new"
+        assert str(handle.get('.')._delegate.nsid) == ".something.totally.new"
 
     def test_get_nonexisting_handle_fail(self):
         ns = Namespace()
@@ -194,7 +194,8 @@ class TestNamespace(unittest.TestCase):
         ns.add(".other.stuff.added.here.now")
 
         handle = ns.get_handle(".other.stuff")
-        assert isinstance(handle.get('.added.here'), NamespaceNodeBase)
+        #assert isinstance(handle.get('.added.here'), NamespaceNodeBase)
+        assert isinstance(handle.get('.added.here'), HandleNode)
 
     def test_handle_add(self):
         ns = Namespace()
@@ -240,7 +241,7 @@ def test_get_subnodes_from_handle():
     subnodes = handle.get_subnodes('.nodes.here.and.there')
     nsids = [str(x.nsid) for x in subnodes]
 
-    assert nsids == ['.a.few.nodes.here.and.there.and', '.a.few.nodes.here.and.there.and.everywhere']
+    assert nsids == ['.nodes.here.and.there.and', '.nodes.here.and.there.and.everywhere']
 
 def test_get_subnodes_from_handle_root():
     ns = Namespace()
@@ -250,7 +251,7 @@ def test_get_subnodes_from_handle_root():
     subnodes = handle.get_subnodes('.')
     nsids = [str(x.nsid) for x in subnodes]
 
-    assert nsids == ['.a.b.c', '.a.b.c.d']
+    assert nsids == ['.c', '.c.d']
 
 
 

--- a/thewired/__init__.py
+++ b/thewired/__init__.py
@@ -6,7 +6,7 @@ from thewired.provider import Provider, get_provider_classes
 from thewired.provider import AddendumFormatter, ParametizedCall, ProviderMap
 from .namespace import Namespace
 from .namespace import NamespaceNode
-from .namespace import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode
+from .namespace import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode, HandleNode
 from .namespace import Nsid
 from .namespaceconfigparser import NamespaceConfigParser
 from .namespaceconfigparser2 import NamespaceConfigParser2

--- a/thewired/namespace/__init__.py
+++ b/thewired/namespace/__init__.py
@@ -1,4 +1,4 @@
 from .namespace import Namespace
 from .namespacenode import NamespaceNode
-from .namespacenode import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode
+from .namespacenode import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode, HandleNode
 from .nsid import Nsid

--- a/thewired/namespace/namespace.py
+++ b/thewired/namespace/namespace.py
@@ -14,7 +14,7 @@ from typing import Union, List, Dict
 from warnings import warn
 
 from thewired.loginfo import make_log_adapter
-from .namespacenode import NamespaceNodeBase
+from .namespacenode import NamespaceNodeBase, HandleNode
 from thewired.namespace.nsid import Nsid, list_nsid_segments, get_parent_nsid, validate_nsid, get_nsid_ancestry, \
                                     strip_common_prefix, find_common_prefix, make_child_nsid, \
                                     nsid_basename, get_nsid_from_ref, is_valid_nsid_ref, get_nsid_from_link, \
@@ -100,6 +100,7 @@ class Namespace(SimpleNamespace):
         n = 0
         while current_node.nsid != _nsid_:
             log.debug(f"target {_nsid_=} != {current_node.nsid=}")
+            print(f"target {_nsid_=} != {current_node.nsid=}")
             try:
                 nsid_segment = nsid_segments[n]
             except IndexError as err:
@@ -348,7 +349,7 @@ class NamespaceHandle(Namespace):
             real_nsid = self.prefix + nsid
 
         log.debug(f"getting {real_nsid=}")
-        return self.ns.get(real_nsid)
+        return HandleNode(self.ns.get(real_nsid), ns_handle=self)
 
 
     def add(self, nsid:Union[str,Nsid], *args, **kwargs) -> List[NamespaceNodeBase]:
@@ -374,7 +375,8 @@ class NamespaceHandle(Namespace):
         for attr_name in dir(start_node):
             attr = getattr(start_node, attr_name)
             if isinstance(attr, NamespaceNodeBase):
-                yield attr
+                handle_node = HandleNode(attr, self)
+                yield handle_node
                 next_nsid = '.' + self.strip_prefix(str(attr.nsid))
 
                 log.debug(f"{next_nsid=}")

--- a/thewired/namespace/namespacenode/__init__.py
+++ b/thewired/namespace/namespacenode/__init__.py
@@ -10,3 +10,4 @@ from .namespacenode import NamespaceNode
 from .base import NamespaceNodeBase
 from .secondlife import SecondLifeNode
 from .delegate import DelegateNode, CallableDelegateNode
+from .handle import HandleNode

--- a/thewired/namespace/namespacenode/delegate.py
+++ b/thewired/namespace/namespacenode/delegate.py
@@ -1,5 +1,6 @@
 from .base import NamespaceNodeBase
 from logging import getLogger, LoggerAdapter
+from ..nsid import Nsid
 
 logger = getLogger(__name__)
 
@@ -9,6 +10,7 @@ class DelegateNode(NamespaceNodeBase):
     """
     def __init__(self, delegate, *, nsid, namespace):
         super().__init__(nsid=nsid, namespace=namespace)
+        self.nsid = Nsid(nsid)
         self._delegate = delegate
 
     def __getattr__(self, attr):

--- a/thewired/namespace/namespacenode/handle.py
+++ b/thewired/namespace/namespacenode/handle.py
@@ -1,0 +1,54 @@
+"""
+Purpose:
+    Namespace Handles return these nodes
+    This is so that a node that is returned from a handle can be referenced with the same handle
+    If we use the canonical NSID in the node returned, the Handle can never refer to that node
+    as the node would have a canonical NSID and the Handle will always add its prefix
+
+    So, instead, we have NamespaceHandles return HandleNodes
+"""
+
+from logging import getLogger
+from .base import NamespaceNodeBase
+
+from thewired.namespace.nsid import strip_common_prefix
+
+from thewired.loginfo import make_log_adapter
+
+
+
+logger = getLogger(__name__)
+
+
+class HandleNode(NamespaceNodeBase):
+#class HandleNode(object):
+    """
+    delegates all missed attribute lookups to <delegate> object via __getattr__
+    overrides NSID as a property to strip the Handle prefix in the nsid
+    """
+    def __init__(self, real_node, ns_handle):
+        self._delegate = real_node
+        self._ns = ns_handle
+
+    def __getattr__(self, attr):
+        print(f"__getattr__: {attr=}")
+        return getattr(self._delegate, attr)
+
+    def __str__(self):
+        return str(self._delegate)
+
+    def __repr__(self):
+        return repr(self._delegate)
+
+    def __dir__(self):
+        return dir(self._delegate)
+
+    @property
+    def nsid(self):
+        hnsid = strip_common_prefix(self._delegate.nsid, self._ns.prefix)[0]
+        print(f"{hnsid=}")
+        return hnsid if hnsid and hnsid[0] == '.' else '.' + hnsid
+
+    @nsid.setter
+    def nsid(self, new_nsid):
+        self._delegate.nsid = new_nsid

--- a/thewired/namespaceconfigparser2.py
+++ b/thewired/namespaceconfigparser2.py
@@ -161,8 +161,8 @@ class NamespaceConfigParser2(object):
                                 setattr(current_node, current_key, _value)
                             elif nsid.is_valid_nsid_link(dictConfig[current_key]):
                                 log.debug(f"Found symbolic link to NSID: {current_key=} {dictConfig[current_key]=}")
-                                log.debug(f"Creating type that can dereference symbolic NSIDs...")
                                 current_nsid = current_node.nsid
+                                log.debug(f"Creating type that can dereference symbolic NSIDs. {current_node.nsid=}")
                                 secondlife = { current_key: dictConfig[current_key] }
                                 factory = partial(SecondLifeNode,
                                         nsid=current_node.nsid,


### PR DESCRIPTION
Fix semantics of NamespaceHandles returning nodes that have NSIDs that can't be reached from the NamespaceHandle that returns them. NamespaceHandles now return HandleNodes which wrap the real node and override the NSID.