### PR TITLE
Add CallableSecondLifeNode type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ ipython = "^8.10.0"
 pytest = "^7.2.0"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.8"]
+build-backend = "poetry.core.masonry.api"

--- a/thewired/__init__.py
+++ b/thewired/__init__.py
@@ -7,7 +7,7 @@ from thewired.provider import AddendumFormatter, ParametizedCall, ProviderMap
 from .namespace import Namespace
 from .namespace import NamespaceNode
 from .namespace import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode, HandleNode
-from .namespace import Nsid
+from .namespace import CallableSecondLifeNode, Nsid
 from .namespaceconfigparser import NamespaceConfigParser
 from .namespaceconfigparser2 import NamespaceConfigParser2
 from .nsidchainmap import NsidChainMap

--- a/thewired/namespace/__init__.py
+++ b/thewired/namespace/__init__.py
@@ -1,4 +1,5 @@
 from .namespace import Namespace
 from .namespacenode import NamespaceNode
 from .namespacenode import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode, HandleNode
+from .namespacenode import CallableSecondLifeNode
 from .nsid import Nsid

--- a/thewired/namespace/__init__.py
+++ b/thewired/namespace/__init__.py
@@ -1,5 +1,6 @@
 from .namespace import Namespace
 from .namespacenode import NamespaceNode
-from .namespacenode import NamespaceNodeBase, SecondLifeNode, DelegateNode, CallableDelegateNode, HandleNode
-from .namespacenode import CallableSecondLifeNode
+from .namespacenode import NamespaceNodeBase, DelegateNode, CallableDelegateNode
+from .namespacenode import HandleNode, CallableHandleNode
+from .namespacenode import SecondLifeNode, CallableSecondLifeNode
 from .nsid import Nsid

--- a/thewired/namespace/namespace.py
+++ b/thewired/namespace/namespace.py
@@ -40,10 +40,13 @@ class Namespace(SimpleNamespace):
             prefix: what namespace prefix is applied to all nodes in this namespace
             default_node_factory: default factory for creating new Nodes in this namespace
         """
+        log = make_log_adapter(logger, self.__class__, "__init__")
+        log.debug("entering")
+        self.root = None
         self._validate_default_node_factory(default_node_factory)
         self.default_node_factory = default_node_factory
-
         self.root = self.default_node_factory(nsid=self._root_nsid, namespace=self)
+
 
 
 
@@ -53,12 +56,16 @@ class Namespace(SimpleNamespace):
             to make it look like everything that's actually under the namespacenode .root is
             actually directly part of the namespace object
         """
+        log = make_log_adapter(logger, self.__class__, "__getattr_")
+        log.debug(f"entering: {attr=}")
         return getattr(self.root, attr)
 
 
     def _validate_default_node_factory(self, func):
+        log = make_log_adapter(logger, self.__class__, "_validate_default_node_factory")
+        log.debug(f"entering: {func=}")
         if not callable(func):
-            raise ValueError(f"default_node_facotry must be callable!")
+            raise ValueError(f"default_node_factory must be callable!")
 
         try:
             x = func(nsid=".a.b.c", namespace=self)
@@ -91,7 +98,8 @@ class Namespace(SimpleNamespace):
             log.debug(f'getting node from NSID symlink')
             nsid = get_nsid_from_link(nsid)
         else:
-            log.debug(f'no nsid-ref nor nsid symlink found')
+            #log.debug(f'no nsid-ref nor nsid symlink found')
+            pass
         self._validate_namespace_nsid_head(nsid)
         _nsid_ = Nsid(nsid)
         current_node = self.root

--- a/thewired/namespace/namespacenode/__init__.py
+++ b/thewired/namespace/namespacenode/__init__.py
@@ -10,4 +10,4 @@ from .namespacenode import NamespaceNode
 from .base import NamespaceNodeBase
 from .secondlife import SecondLifeNode, CallableSecondLifeNode
 from .delegate import DelegateNode, CallableDelegateNode
-from .handle import HandleNode
+from .handle import HandleNode, CallableHandleNode

--- a/thewired/namespace/namespacenode/__init__.py
+++ b/thewired/namespace/namespacenode/__init__.py
@@ -8,6 +8,6 @@ Purpose:
 """
 from .namespacenode import NamespaceNode
 from .base import NamespaceNodeBase
-from .secondlife import SecondLifeNode
+from .secondlife import SecondLifeNode, CallableSecondLifeNode
 from .delegate import DelegateNode, CallableDelegateNode
 from .handle import HandleNode

--- a/thewired/namespace/namespacenode/base.py
+++ b/thewired/namespace/namespacenode/base.py
@@ -12,7 +12,8 @@ from typing import Union
 
 from thewired.namespace.nsid import Nsid
 
-from thewired.loginfo import make_log_adapter
+#from thewired.loginfo import make_log_adapter
+from logging import LoggerAdapter
 
 ###
 # type aliases
@@ -43,7 +44,7 @@ class NamespaceNodeBase(SimpleNamespace):
         Input:
             nsid: namespace id of this node
         """
-        log = make_log_adapter(logger, self.__class__, "__init__")
+        log = LoggerAdapter(logger, dict(name_ext=f"NamespaceNodeBase.__init__"))
         log.debug(f"calling super().__init__: {nsid=} | {namespace=} | {args=} | {kwargs=}")
         super().__init__(*args, **kwargs)
         self.nsid = Nsid(nsid)

--- a/thewired/namespace/namespacenode/base.py
+++ b/thewired/namespace/namespacenode/base.py
@@ -49,6 +49,7 @@ class NamespaceNodeBase(SimpleNamespace):
         super().__init__(*args, **kwargs)
         self.nsid = Nsid(nsid)
         self._ns = namespace
+        self._cache = None
         log.debug("exiting")
 
     def __repr__(self):

--- a/thewired/namespace/namespacenode/base.py
+++ b/thewired/namespace/namespacenode/base.py
@@ -43,9 +43,12 @@ class NamespaceNodeBase(SimpleNamespace):
         Input:
             nsid: namespace id of this node
         """
+        log = make_log_adapter(logger, self.__class__, "__init__")
+        log.debug(f"calling super().__init__: {nsid=} | {namespace=} | {args=} | {kwargs=}")
         super().__init__(*args, **kwargs)
         self.nsid = Nsid(nsid)
         self._ns = namespace
+        log.debug("exiting")
 
     def __repr__(self):
         return f"{self.__class__.__name__}(nsid=\"{self.nsid}\")"

--- a/thewired/namespace/namespacenode/handle.py
+++ b/thewired/namespace/namespacenode/handle.py
@@ -50,3 +50,21 @@ class HandleNode(DelegateNode):
     @nsid.setter
     def nsid(self, new_nsid):
         self._delegate.nsid = new_nsid
+
+
+
+class CallableHandleNode(HandleNode):
+    """
+    same as HandleNode, but dunders must be instantiated into slots (can't be added after construction)
+    so, we add the __call__ dunder as part of the definition to make it callable
+
+    requires that the delegate itself is callable
+    """
+    def __init__(self, real_node, ns_handle):
+        super().__init__(real_node, ns_handle)
+
+    def __call__(self, *args, **kwargs):
+        return self._delegate(*args, **kwargs)
+
+    def __repr__(self):
+        return "CallableHandleNode(" + repr(self._delegate) + ")"

--- a/thewired/namespace/namespacenode/secondlife.py
+++ b/thewired/namespace/namespacenode/secondlife.py
@@ -66,3 +66,20 @@ class SecondLifeNode(NamespaceNodeBase):
 
     def __repr__(self):
         return f"{self.__class__.__name__}(nsid={self.nsid}, namespace={self._ns}, secondlifens={self._secondlife_ns},secondlife={self._secondlife})"
+
+
+class CallableSecondLifeNode(SecondLifeNode):
+    def __init__(self, *args, nsid, namespace, secondlife_ns=None, secondlife=None, **kwargs):
+        super().__init__(self, *args, nsid=nsid, namespace=namespace, secondLife_ns=secondLife_ns, secondLife=secondLife, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__call__'))
+        log.debug("Entering")
+        callable_node = self.secondlife.get('__call__', self._attribute_lookup_fail_canary)
+        if x == self._attribute_lookup_fail_canary:
+            log.debug("No __call__ key in secondlifedict")
+            return None
+
+        x = callable_node(*args, **args)
+        log.debug("secondlife['__call__']() returned {x}")
+        return x

--- a/thewired/namespace/namespacenode/secondlife.py
+++ b/thewired/namespace/namespacenode/secondlife.py
@@ -32,7 +32,7 @@ class SecondLifeNode(NamespaceNodeBase):
                         - thus the node referred to must be callable
                     * anything else - if it doesn't match the others, return this value exactly as it is
         """
-        log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__init__'))
+        log = LoggerAdapter(logger, dict(name_ext=f'SecondLifeNode.__init__'))
         log.debug("entering")
         log.debug(f"Calling super().__init__: {args=} | {nsid=} | {namespace=} | {kwargs=}")
         super().__init__(*args, nsid=nsid, namespace=namespace, **kwargs)
@@ -75,20 +75,20 @@ class SecondLifeNode(NamespaceNodeBase):
 
 class CallableSecondLifeNode(SecondLifeNode):
     def __init__(self, *args, nsid, namespace, secondlife_ns=None, secondlife=None, **kwargs):
-        log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__init__'))
+        log = LoggerAdapter(logger, dict(name_ext=f'CallableSecondLifeNode.__init__'))
         log.debug("entering")
         log.debug(f"Calling super().__init__: {args=} | {nsid=} | {namespace=} | {secondlife_ns=} | {secondlife=} | {kwargs=}")
-        super().__init__(*args, nsid=nsid, namespace=namespace, secondLife_ns=secondlife_ns, secondLife=secondlife, **kwargs)
+        super().__init__(*args, nsid=nsid, namespace=namespace, secondlife_ns=secondlife_ns, secondlife=secondlife, **kwargs)
         log.debug("exiting")
 
     def __call__(self, *args, **kwargs):
         log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__call__'))
         log.debug(f"Entering: {args=} | {kwargs=}")
         callable_node = self._secondlife.get('__call__', self._attribute_lookup_fail_canary)
-        if x == self._attribute_lookup_fail_canary:
+        if callable_node == self._attribute_lookup_fail_canary:
             log.debug("No __call__ key in secondlifedict")
             return None
 
-        x = callable_node(*args, **args)
+        x = callable_node(*args, **kwargs)
         log.debug("secondlife['__call__']() returned {x}")
         return x

--- a/thewired/namespace/namespacenode/secondlife.py
+++ b/thewired/namespace/namespacenode/secondlife.py
@@ -32,14 +32,18 @@ class SecondLifeNode(NamespaceNodeBase):
                         - thus the node referred to must be callable
                     * anything else - if it doesn't match the others, return this value exactly as it is
         """
+        log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__init__'))
+        log.debug("entering")
+        log.debug(f"Calling super().__init__: {args=} | {nsid=} | {namespace=} | {kwargs=}")
         super().__init__(*args, nsid=nsid, namespace=namespace, **kwargs)
         self._secondlife = secondlife
         self._attribute_lookup_fail_canary = "__ATTRIBUTE_LOOKUP_FAIL_CANARY__"
         self._secondlife_ns = secondlife_ns if secondlife_ns else self._ns
+        log.debug("exiting")
 
     def __getattr__(self, attr):
         log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__getattr__'))
-        log.debug("entering")
+        log.debug(f"entering: {attr=}")
         secondlife_value = None
         raw_attr_value = self._secondlife.get(attr, self._attribute_lookup_fail_canary)
 
@@ -62,6 +66,7 @@ class SecondLifeNode(NamespaceNodeBase):
             #- whatever it is, just return it raw
             secondlife_value = raw_attr_value
 
+        log.debug(f"exiting: {secondlife_value=}")
         return secondlife_value
 
     def __repr__(self):
@@ -70,12 +75,16 @@ class SecondLifeNode(NamespaceNodeBase):
 
 class CallableSecondLifeNode(SecondLifeNode):
     def __init__(self, *args, nsid, namespace, secondlife_ns=None, secondlife=None, **kwargs):
-        super().__init__(self, *args, nsid=nsid, namespace=namespace, secondLife_ns=secondLife_ns, secondLife=secondLife, **kwargs)
+        log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__init__'))
+        log.debug("entering")
+        log.debug(f"Calling super().__init__: {args=} | {nsid=} | {namespace=} | {secondlife_ns=} | {secondlife=} | {kwargs=}")
+        super().__init__(*args, nsid=nsid, namespace=namespace, secondLife_ns=secondlife_ns, secondLife=secondlife, **kwargs)
+        log.debug("exiting")
 
     def __call__(self, *args, **kwargs):
         log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.__call__'))
-        log.debug("Entering")
-        callable_node = self.secondlife.get('__call__', self._attribute_lookup_fail_canary)
+        log.debug(f"Entering: {args=} | {kwargs=}")
+        callable_node = self._secondlife.get('__call__', self._attribute_lookup_fail_canary)
         if x == self._attribute_lookup_fail_canary:
             log.debug("No __call__ key in secondlifedict")
             return None

--- a/thewired/namespace/namespacenode/secondlife.py
+++ b/thewired/namespace/namespacenode/secondlife.py
@@ -90,5 +90,6 @@ class CallableSecondLifeNode(SecondLifeNode):
             return None
 
         x = callable_node(*args, **kwargs)
-        log.debug("secondlife['__call__']() returned {x}")
+        log.debug(f"secondlife['__call__']() returned {x}")
+        self._cache = x
         return x

--- a/thewired/namespaceconfigparser2.py
+++ b/thewired/namespaceconfigparser2.py
@@ -96,8 +96,7 @@ class NamespaceConfigParser2(object):
             a namespace object representing the nodes specifed in the dictConfig object
         """
         log = LoggerAdapter(logger, dict(name_ext=f'{self.__class__.__name__}.parse'))
-
-        log.debug(f"enter: {self.ns=} {prefix=} {dictConfig=}")
+        log.debug(f"entering: {self.ns=} {prefix=} {dictConfig=}")
         ns = self.ns
         lookup_ns = self.lookup_ns
 
@@ -127,7 +126,7 @@ class NamespaceConfigParser2(object):
                 if node_factory:
                     if current_key is None:
                         #add new node in place of / overwriting previous node
-                        log.debug("special case node path detected: overwrite previous node, place new one at {prefix=}")
+                        log.debug(f"special case node path detected: overwrite previous node, place new one at {prefix=}")
                         try:
                             ns.remove(prefix)
                         except NamespaceError as e:
@@ -175,7 +174,7 @@ class NamespaceConfigParser2(object):
                             setattr(current_node, current_key, dictConfig[current_key])
 
 
-                log.debug(f"{ns=}")
+                log.debug(f"exiting: {current_key=}")
 
         return ns
 
@@ -380,7 +379,7 @@ class NamespaceConfigParser2(object):
                     node_factory = getattr(nf_module, nf_symbol_name)
                 except AttributeError as err:
                     log.debug("specified factory function does not exist in specified module!")
-                    raise ValueError("parsed factory function does not exist in specified module!") from err
+                    raise ValueError(f"parsed factory function ({nf_symbol_name}) does not exist in specified module ({nf_module})!") from err
 
                 if not callable(node_factory):
                     log.debug(f"specified node factory is not callable! {dictConfig=}")


### PR DESCRIPTION
`__call__` has to be in slots, so you can't do that 100% dynamically as the object is either callable or is not callable at the C API level. So create a new type that is Callable.